### PR TITLE
Scenario tabs

### DIFF
--- a/R/scenario_module.R
+++ b/R/scenario_module.R
@@ -1,0 +1,154 @@
+
+# understand logic for prevalence and transition
+# (TODO: why does it work without tagList? is tagList not always necessary?)
+# TODO: "remove" the tab with a button?
+
+single_scenario_ui <- function(id, prevalence_and_transition_choices) {
+  ns <- NS(id)
+
+  prevalence_and_transition_choices <- prevalence_and_transition_choices()
+
+  ui_min_age <- 0
+  ui_max_age <- 95
+  prevalence_choices <- prevalence_and_transition_choices$prevalences
+  transition_choices <- prevalence_and_transition_choices$transitions
+
+  fluidRow(column(4,
+                  textInput(ns("scenario_name"),
+                            "Scenario name:",
+                            value = ""),
+                  numericInput(ns("percent_population"),
+                               "% of Population Reached:",
+                               value = 100, min = 0, max = 100),
+                  radioButtons(ns("gender"), "Gender:",
+                               choiceNames=c("male", "female", "male and female"),
+                               choiceValues=c(0, 1, 2),
+                               selected = 2)
+           ),
+           column(8,
+                  numericInput(ns("min_age"),
+                               "Min. Age:",
+                               value = ui_min_age,
+                               min = ui_min_age,
+                               max = ui_max_age),
+                  numericInput(ns("max_age"),
+                               "Max. Age:",
+                               value = ui_max_age,
+                               min = ui_min_age,
+                               max = ui_max_age),
+                  selectInput(ns("prevalence"),
+                              "Prevalence:",
+                              choices = prevalence_choices),
+                  selectInput(ns("transition"),
+                              "Transition:",
+                              choices = transition_choices)
+           )
+  )
+}
+
+
+single_scenario_server <- function(id, reference_data) {
+  moduleServer(id, function(input, output, session) {
+
+    reactive({
+      current_inputs <- list()
+      if (!is.null(reference_data())) {
+        current_inputs <- list(
+          scenario_name = input$scenario_name,
+          percent_population = input$percent_population,
+          gender = as.integer(input$gender),
+          min_age = input$min_age,
+          max_age = input$max_age,
+          prevalence = input$prevalence,
+          transition = input$transition
+        )
+        return(current_inputs)
+      }
+    })
+  })
+}
+
+scenario_ui <- function(id, reference_data) {
+  ns <- NS(id)
+
+  tagList(
+    actionButton(ns("add_scenario"), "Add Scenario"),
+    actionButton(ns("remove_scenario"), "Remove last scenario"),
+    tabsetPanel(id = ns("tabs"), type = "tabs")
+  )
+}
+
+
+scenario_server <- function(id, reference_data) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    scenario_count <- reactiveVal(0)
+    scenario_servers <- reactiveValues(servers = list())
+    server_name_prefix <- "scenario_"
+    prevalence_and_incidence_choices <- reactiveVal(NULL)
+
+    observeEvent(reference_data(), {
+      transitions <- lapply(reference_data()$risk_factors, function(x) names(x[["Transitions"]]))
+      prevalences <- lapply(reference_data()$risk_factors, function(x) names(x[["Prevalences"]]))
+      prevalence_and_incidence_choices(list(
+        transitions = transitions,
+        prevalences = prevalences
+      ))
+    })
+
+    observeEvent(input$add_scenario, {
+      new_count <- scenario_count() + 1
+      scenario_count(new_count)
+
+      appendTab(
+        inputId = "tabs",
+        tabPanel(
+          title = paste("Scenario", new_count),
+          single_scenario_ui(ns(paste0(server_name_prefix, new_count)), prevalence_and_incidence_choices)
+        ),
+        select = TRUE
+      )
+
+      server_name <- paste0(server_name_prefix, new_count)
+      scenario_servers$servers[[server_name]] <- single_scenario_server(
+        server_name, reference_data
+      )
+    })
+
+    observeEvent(input$remove_scenario, {
+
+      old_count <- scenario_count()
+      server_name <- paste0(server_name_prefix, old_count)
+      removeTab(
+        inputId = "tabs",
+        target = paste("Scenario", old_count)
+      )
+      new_count <- max(old_count - 1, 0)
+      if (new_count > 0) {
+        current_server_names <- names(scenario_servers$servers)
+        new_server_names <- current_server_names[c(1:new_count)]
+        new_server_set <- sapply(new_server_names, function(x) {
+          scenario_servers$servers[[x]]
+        }, simplify = FALSE, USE.NAMES = TRUE)
+      } else {
+        new_server_set <- NULL
+      }
+      scenario_servers$servers <- new_server_set
+      scenario_count(new_count)
+    })
+
+    user_data <- reactive({
+      fetch_server_data(
+        server_name_prefix = server_name_prefix,
+        server_list = scenario_servers$servers,
+        item_names = names(scenario_servers$servers)
+      )
+    })
+
+    return(user_data)
+  })
+}
+
+
+

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,4 @@
+.onLoad <- function(libname, pkgname) {
+  resources <- system.file("application/www", package = "hiaR")
+  addResourcePath("www", resources)
+}

--- a/inst/application/app.R
+++ b/inst/application/app.R
@@ -1,4 +1,4 @@
-
+# TODO: add functionality for debugging? -> only if debugging is true, then show the outputs of each UI (see end of this script)
 ui <- fluidPage(
   navbarPage("DYNAMO-HIA",
              tabPanel("Configuration",
@@ -25,7 +25,10 @@ ui <- fluidPage(
                       ),
              tabPanel("Relative Risks",
                       uiOutput("relative_risk_ui"),
-                      verbatimTextOutput("selected_relative_risk_display"))
+                      verbatimTextOutput("selected_relative_risk_display")),
+             tabPanel("Scenarios",
+                      uiOutput("scenario_ui"),
+                      verbatimTextOutput("selected_scenarios_display"))
   )
 )
 
@@ -77,6 +80,12 @@ server <- function(input, output, session) {
   selected_relative_risks <- relative_risk_server(
     "relative_risks", available_relative_risks)
 
+  output$scenario_ui <- renderUI({
+    req(reference_data())
+    scenario_ui("scenarios", reference_data)
+  })
+  selected_scenarios <- scenario_server("scenarios", reference_data)
+
   # Update the choice options for relative risks ratios into diseases
   # depending on user input from selected risk factors and diseases
   observe({ # https://groups.google.com/g/shiny-discuss/c/vd_nB-BH8sw
@@ -107,6 +116,9 @@ server <- function(input, output, session) {
     output$selected_relative_risk_display <- renderPrint({ selected_relative_risks() })
   })
 
+  observeEvent(selected_scenarios(), {
+    output$selected_scenarios_display <- renderPrint({ selected_scenarios() })
+  })
 
 }
 

--- a/inst/application/www/script.js
+++ b/inst/application/www/script.js
@@ -1,0 +1,8 @@
+Shiny.addCustomMessageHandler('addbutton', function(message) {
+  var button = "<li class='list_button'><button type='button' class='btn btn-success' onclick='trigger_shiny(\"" + message.trigger + "\")'><i class='fa fa-plus'></i></button></li>";
+  $("#" + message.id).first().prepend(button);
+});
+
+function trigger_shiny(trigger, value = 1) {
+  Shiny.setInputValue(trigger, value, {priority: "event"});
+}

--- a/inst/application/www/style.css
+++ b/inst/application/www/style.css
@@ -1,0 +1,5 @@
+.list_button {
+  margin-left: 5px;
+  margin-right: 15px;
+  transform: scale(0.9);
+}


### PR DESCRIPTION
This is a work in progress
- up until ff2456039ad7e77f5a3d73b5a9aa839d0feba3ab is what I showed Malte yesterday. One can only close the latest tab, but everything works
- the latest commit tries something nicer: a "+" button to add tabs, and each tab can be closed with "X". It looks nice, but the reactivity is not working unfortunately at the moment. possible reasons: (1) I have not placed the javascript code correctly in the package (see links below), (2) something is wrong with the reactivity in the `scenario_module.R` script. (3) I do not fully understand this code: the approach here of managing child servers is taken from the example below, and is slightly different from what we did in the other modules. 

In the interest of time, maybe we can merge the functioning code? I would still like to try the nicer version though, but maybe you can have a look/we have a look together? I followed these links
- https://www.harveyl888.com/post/2022-01-01-dynamic_tabs/
	- code here: https://github.com/harveyl888/shiny_dynamic_tabs/tree/main. this works for me
- https://shiny.posit.co/r/articles/build/packaging-javascript/
- https://stackoverflow.com/questions/63360170/shiny-app-as-package-css-all-www-directory-stuff